### PR TITLE
feat: allow using groups layout with cpp tester

### DIFF
--- a/checker/actions/check.py
+++ b/checker/actions/check.py
@@ -23,6 +23,7 @@ def _check_single_task(
     reference_config_dir = private_course_driver.get_task_config_dir(task)
     reference_public_tests_dir = private_course_driver.get_task_public_test_dir(task)
     reference_private_tests_dir = private_course_driver.get_task_private_test_dir(task)
+    reference_tests_root_dir = private_course_driver.root_dir
     assert reference_source_dir, 'reference_source_dir have to exists'
     assert reference_config_dir, 'reference_config_dir have to exists'
     assert reference_public_tests_dir or reference_private_tests_dir, \
@@ -38,6 +39,7 @@ def _check_single_task(
                     reference_config_dir,
                     reference_public_tests_dir,
                     reference_private_tests_dir,
+                    reference_tests_root_dir,
                     verbose=verbose,
                     normalize_output=True,
                 )
@@ -54,6 +56,7 @@ def _check_single_task(
             reference_config_dir,
             reference_public_tests_dir,
             reference_private_tests_dir,
+            reference_tests_root_dir,
             verbose=verbose,
             normalize_output=True,
         )

--- a/checker/actions/grade.py
+++ b/checker/actions/grade.py
@@ -160,6 +160,7 @@ def grade_single_task(
     reference_config_dir = private_course_driver.get_task_config_dir(task)
     reference_public_tests_dir = private_course_driver.get_task_public_test_dir(task)
     reference_private_tests_dir = private_course_driver.get_task_private_test_dir(task)
+    reference_tests_root_dir = private_course_driver.root_dir
     assert source_dir, 'source_dir have to exists'
     assert reference_config_dir, 'reference_config_dir have to exists'
     assert reference_public_tests_dir or reference_private_tests_dir, \
@@ -171,6 +172,7 @@ def grade_single_task(
             reference_config_dir,
             reference_public_tests_dir,
             reference_private_tests_dir,
+            reference_tests_root_dir,
             verbose=inspect,
             normalize_output=inspect,
         )

--- a/checker/testers/cpp.py
+++ b/checker/testers/cpp.py
@@ -46,6 +46,7 @@ class CppTester(Tester):
             source_dir: Path,
             public_tests_dir: Path | None,
             private_tests_dir: Path | None,
+            tests_root_dir: Path,
             sandbox: bool = True,
             verbose: bool = False,
             normalize_output: bool = False,
@@ -56,9 +57,7 @@ class CppTester(Tester):
             patterns=test_config.allow_change,
             raise_on_found=True,
         )
-        reference_root = public_tests_dir.parent  # type: ignore
-        task_name = source_dir.name
-        task_dir = reference_root / task_name
+        task_dir = public_tests_dir
         self._executor(
             copy_files,
             source=source_dir,
@@ -77,7 +76,7 @@ class CppTester(Tester):
         try:
             print_info('Running cmake...', color='orange')
             self._executor(
-                ['cmake', '-G', 'Ninja', str(reference_root),
+                ['cmake', '-G', 'Ninja', str(tests_root_dir),
                  '-DGRADER=YES', '-DENABLE_PRIVATE_TESTS=YES',
                  f'-DCMAKE_BUILD_TYPE={test_config.build_type}'],
                 cwd=build_dir,
@@ -104,7 +103,7 @@ class CppTester(Tester):
 
         try:
             print_info('Running clang format...', color='orange')
-            format_path = reference_root / 'run-clang-format.py'
+            format_path = tests_root_dir / 'run-clang-format.py'
             self._executor(
                 [str(format_path), '-r', str(task_dir)],
                 cwd=build_dir,

--- a/checker/testers/make.py
+++ b/checker/testers/make.py
@@ -24,6 +24,7 @@ class MakeTester(Tester):
             source_dir: Path,
             public_tests_dir: Path | None,
             private_tests_dir: Path | None,
+            tests_root_dir: Path,
             sandbox: bool = True,
             verbose: bool = False,
             normalize_output: bool = False,

--- a/checker/testers/python.py
+++ b/checker/testers/python.py
@@ -60,6 +60,7 @@ class PythonTester(Tester):
             source_dir: Path,
             public_tests_dir: Path | None,
             private_tests_dir: Path | None,
+            tests_root_dir: Path,
             sandbox: bool = True,
             verbose: bool = False,
             normalize_output: bool = False,

--- a/checker/testers/tester.py
+++ b/checker/testers/tester.py
@@ -107,6 +107,7 @@ class Tester:
             source_dir: Path,
             public_tests_dir: Path | None,
             private_tests_dir: Path | None,
+            tests_root_dir: Path,
             sandbox: bool = True,
             verbose: bool = False,
             normalize_output: bool = False,
@@ -167,6 +168,7 @@ class Tester:
             config_dir: Path,
             public_tests_dir: Path | None,
             private_tests_dir: Path | None,
+            tests_root_dir: Path,
             verbose: bool = False,
             normalize_output: bool = False,
     ) -> float:
@@ -198,6 +200,7 @@ class Tester:
                 source_dir,
                 public_tests_dir,
                 private_tests_dir,
+                tests_root_dir,
                 sandbox=True,
                 verbose=verbose,
                 normalize_output=normalize_output,

--- a/tests/testers/test_cpp.py
+++ b/tests/testers/test_cpp.py
@@ -38,7 +38,13 @@ def init_task(tmp_path: Path, code: str, **kwargs):
 
     format_path = reference_dir / 'run-clang-format.py'
     format_path.chmod(format_path.stat().st_mode | stat.S_IEXEC)
-    return source_dir, private_tests_dir, public_tests_dir, private_tests_dir
+    return (
+        source_dir,
+        private_tests_dir, # config_dir
+        public_tests_dir,
+        private_tests_dir,
+        reference_dir, # tests_root_dir
+    )
 
 
 STAGE_BUILD = 1

--- a/tests/testers/test_python.py
+++ b/tests/testers/test_python.py
@@ -73,7 +73,7 @@ class TestPythonTester:
         """
         create_single_file_task(tmp_path, CODE, PUBLIC_TESTS, PRIVATE_TESTS)
 
-        score = python_tester.test_task(tmp_path, tmp_path, tmp_path, tmp_path, normalize_output=True)
+        score = python_tester.test_task(tmp_path, tmp_path, tmp_path, tmp_path, tmp_path, normalize_output=True)
         assert score == 1
 
         captures = capsys.readouterr()
@@ -98,7 +98,7 @@ class TestPythonTester:
         create_single_file_task(tmp_path, CODE, PUBLIC_TESTS)
 
         with pytest.raises(StylecheckFailedError):
-            python_tester.test_task(tmp_path, tmp_path, tmp_path, tmp_path, normalize_output=True)
+            python_tester.test_task(tmp_path, tmp_path, tmp_path, tmp_path, tmp_path, normalize_output=True)
 
     def test_disabled_mypy_error(
             self,
@@ -119,7 +119,7 @@ class TestPythonTester:
         """
         create_single_file_task(tmp_path, CODE, PUBLIC_TESTS, tester_config=CONFIG)
 
-        python_tester.test_task(tmp_path, tmp_path, tmp_path, tmp_path, normalize_output=True)
+        python_tester.test_task(tmp_path, tmp_path, tmp_path, tmp_path, tmp_path, normalize_output=True)
 
         captures = capsys.readouterr()
         assert 'Running mypy checks...' not in captures.err
@@ -143,7 +143,7 @@ class TestPythonTester:
         create_single_file_task(tmp_path, CODE, PUBLIC_TESTS, tester_config=CONFIG)
 
         with pytest.raises(StylecheckFailedError):
-            python_tester.test_task(tmp_path, tmp_path, tmp_path, tmp_path, normalize_output=True)
+            python_tester.test_task(tmp_path, tmp_path, tmp_path, tmp_path, tmp_path, normalize_output=True)
 
     def test_ruff_error(
             self,
@@ -164,7 +164,7 @@ class TestPythonTester:
         create_single_file_task(tmp_path, CODE, PUBLIC_TESTS, tester_config=CONFIG)
 
         with pytest.raises(StylecheckFailedError):
-            python_tester.test_task(tmp_path, tmp_path, tmp_path, tmp_path, normalize_output=True)
+            python_tester.test_task(tmp_path, tmp_path, tmp_path, tmp_path, tmp_path, normalize_output=True)
 
     def test_pytest_error(
             self,
@@ -185,7 +185,7 @@ class TestPythonTester:
         create_single_file_task(tmp_path, CODE, PUBLIC_TESTS, tester_config=CONFIG)
 
         with pytest.raises(TestsFailedError) as ex:
-            python_tester.test_task(tmp_path, tmp_path, tmp_path, tmp_path, normalize_output=True)
+            python_tester.test_task(tmp_path, tmp_path, tmp_path, tmp_path, tmp_path, normalize_output=True)
 
     def test_pytest_error_no_duble_error(
             self,
@@ -208,7 +208,7 @@ class TestPythonTester:
             create_single_file_task(tmp_path, CODE, PUBLIC_TESTS, tester_config=CONFIG)
 
         with pytest.raises(TestsFailedError) as ex:
-            python_tester.test_task(tmp_path, tmp_path, tmp_path, tmp_path, normalize_output=True)
+            python_tester.test_task(tmp_path, tmp_path, tmp_path, tmp_path, tmp_path, normalize_output=True)
         captured = capsys.readouterr()
 
         assert captured.err.count('short test summary info ') == 1
@@ -237,7 +237,7 @@ class TestPythonTester:
         """
         create_single_file_task(tmp_path, CODE, PUBLIC_TESTS, tester_config=CONFIG, setup_file=SETUP)
 
-        score = python_tester.test_task(tmp_path, tmp_path, tmp_path, tmp_path, normalize_output=True)
+        score = python_tester.test_task(tmp_path, tmp_path, tmp_path, tmp_path, tmp_path, normalize_output=True)
         assert score == 1
 
         captures = capsys.readouterr()


### PR DESCRIPTION
C++ tester only supports `flat` layout right now because it runs build as `cmake ${task_dir}/..` assuming that the project root is located one directory up from the task dir.\
This PR adds support for the `groups` layout while preserving functionality for the `flat` layout.