### PR TITLE
Don't suggest exposing DOCKER_AUTH_CONFIG to student repos

### DIFF
--- a/docs/system_setup.md
+++ b/docs/system_setup.md
@@ -210,6 +210,5 @@ So you need to select in private repo CI/CD Settings `.releaser-ci.yml` as ci fi
 
 * In gitlab.manytask.org -> [course_group]  
   Set variables for checker and gitlab runner to operate   
-  * DOCKER_AUTH_CONFIG (none),  
   * TESTER_TOKEN (masked),  
   * GITLAB_SERVICE_TOKEN (masked) 


### PR DESCRIPTION
This token, if not masked, can be seen by students and allows sensitive data leaks. It is only used in runners setup, not in the CI jobs, hence it should never be set in the group configuration.