### PR TITLE
fix: be aware of timezone in timestep

### DIFF
--- a/checker/__main__.py
+++ b/checker/__main__.py
@@ -242,16 +242,15 @@ def _parse_timestamp(
     ctx: click.Context,
     param: click.Parameter,
     value: Optional[str],
-    ) -> datetime:
+) -> datetime:
     if value is None:
         # runtime default
         return datetime.now(tz=ZoneInfo("Europe/Moscow"))
     try:
         return datetime.fromisoformat(value)
     except ValueError as e:
-        raise click.BadParameter(
-        "Use ISO 8601, e.g. 2025-09-08T13:39:13 or 2025-09-08T13:39:13Z"
-    ) from e
+        raise click.BadParameter("Use ISO 8601, e.g. 2025-09-08T13:39:13 or 2025-09-08T13:39:13Z") from e
+
 
 @cli.command()
 @click.argument("root", type=ClickReadableDirectory, default=".")


### PR DESCRIPTION
After GitLab was updated it started to send time with suffix, which broke the checker. This fixes the problem by processing the timestamp and use the timezone suffix if it exists.