### PR TITLE
✨ Allow partial scoring for tasks with `partially_scored` arg

### DIFF
--- a/checker/pipeline.py
+++ b/checker/pipeline.py
@@ -254,11 +254,11 @@ class PipelineRunner:
                 _end_time = time.perf_counter()
                 print_info(e.output or "[empty output]")
                 print_info(f"> elapsed time: {_end_time - _start_time:.2f}s", color="grey")
-                
+
                 allow_partial = bool(resolved_args.get("partially_scored", False))
                 if allow_partial:
                     print_info("error! (ignored due to partially_scored)", color="yellow")
-                
+
                 pipeline_stage_results.append(
                     PipelineStageResult(
                         name=pipeline_stage.name,
@@ -269,7 +269,7 @@ class PipelineRunner:
                         elapsed_time=_end_time - _start_time,
                     )
                 )
-                
+
                 if not allow_partial:  # only apply failure handling when not partial
                     if pipeline_stage.fail == PipelineStageConfig.FailType.FAST:
                         print_info("error! (now as fail=fast)", color="red")


### PR DESCRIPTION
## Add partial scoring support for pipeline stages

This PR introduces support for partial scoring in pipeline stages when plugins fail but still contribute a meaningful score.

### Changes
- Added `partially_scored` argument support in pipeline stage configuration
- When `partially_scored=true` and a plugin fails with `PluginExecutionFailed`, the stage is marked as non-failed but preserves the partial percentage score
- Failure handling logic (fail-fast, fail-after-all, etc.) is bypassed for partial scoring stages
- Added yellow warning message when partial scoring is applied

### Use case
This enables scenarios where some tests pass and others fail, but you still want to award partial credit rather than failing the entire pipeline. Useful for educational contexts where partial solutions should be recognized.

### Example configuration
```yaml
- name: "Run tests with partial scoring"
  run: "pytest"
  args:
    partially_scored: true
    # other args...
```

The implementation is minimal and backward-compatible - existing pipelines continue to work unchanged.