### PR TITLE
Fix prefix detection bug

### DIFF
--- a/checker/course.py
+++ b/checker/course.py
@@ -247,7 +247,7 @@ class Course:
             changed_tasks = [
                 task
                 for task in potential_tasks
-                if any(file is not None and Path(file).is_relative_to(task.relative_path + os.path.sep) for file in changed_files)
+                if any(file is not None and Path(file).is_relative_to(os.path.sep + task.relative_path + os.path.sep) for file in changed_files)
             ]
             print_info(
                 f"Changed tasks: {[t.name for t in changed_tasks]} (changed files in last commit)",


### PR DESCRIPTION
There was a problem with this line
```
if any(file is not None and Path(file).is_relative_to(task.relative_path) for file in changed_files)
```

Because of it we have problem, when name of the task is the substring of other task's name, checker also checked this 'substring' task. Now it solved.
```
if any(file is not None and Path(file).is_relative_to(os.path.sep + task.relative_path + os.path.sep) for file in changed_files)
```

Because of os.path.sep in both sides of task.relative_path, now will match only if task name mathes subpath to file.
