### PR TITLE
feat: merge features from the CUDA course branch

### DIFF
--- a/checker/plugins/cpp_clang_format.py
+++ b/checker/plugins/cpp_clang_format.py
@@ -32,7 +32,7 @@ class CppClangFormatPlugin(PluginABC):
                 "python3",
                 "run-clang-format.py",
                 "--clang-format-executable",
-                "clang-format-19",
+                "clang-format-20",
                 "--color",
                 "always",
                 "-r",

--- a/checker/plugins/cpp_clang_tidy.py
+++ b/checker/plugins/cpp_clang_tidy.py
@@ -18,7 +18,7 @@ class CppClangTidyPlugin(PluginABC):
         reference_root: Path
         task_path: Path
         lint_patterns: list[str]
-        build_type: Optional[str]
+        build_type: str = "build-asan"
 
     def _run(self, args: Args, *, verbose: bool = False) -> PluginOutput:  # type: ignore[override]
         lint_files = []
@@ -30,7 +30,7 @@ class CppClangTidyPlugin(PluginABC):
             raise PluginExecutionFailed("No files")
 
         run_args = SafeRunScriptPlugin.Args(
-            origin=str(args.reference_root / (args.build_type if args.build_type is not None else "build-asan")),
+            origin=str(args.reference_root / args.build_type),
             script=["clang-tidy-20", "-p", ".", "--use-color", "--quiet", *lint_files],
             paths_whitelist=[str(args.reference_root)],
             paths_blacklist=get_cpp_blacklist(args.reference_root),

--- a/checker/plugins/cpp_clang_tidy.py
+++ b/checker/plugins/cpp_clang_tidy.py
@@ -31,7 +31,7 @@ class CppClangTidyPlugin(PluginABC):
 
         run_args = SafeRunScriptPlugin.Args(
             origin=str(args.reference_root / (args.build_type if args.build_type is not None else "build-asan")),
-            script=["clang-tidy-19", "-p", ".", "--use-color", "--quiet", *lint_files],
+            script=["clang-tidy-20", "-p", ".", "--use-color", "--quiet", *lint_files],
             paths_whitelist=[str(args.reference_root)],
             paths_blacklist=get_cpp_blacklist(args.reference_root),
         )

--- a/checker/plugins/cpp_clang_tidy.py
+++ b/checker/plugins/cpp_clang_tidy.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Optional
 
 from checker.exceptions import PluginExecutionFailed
 from checker.plugins.cpp.blacklist import get_cpp_blacklist
@@ -17,6 +18,7 @@ class CppClangTidyPlugin(PluginABC):
         reference_root: Path
         task_path: Path
         lint_patterns: list[str]
+        build_type: Optional[str]
 
     def _run(self, args: Args, *, verbose: bool = False) -> PluginOutput:  # type: ignore[override]
         lint_files = []
@@ -28,7 +30,7 @@ class CppClangTidyPlugin(PluginABC):
             raise PluginExecutionFailed("No files")
 
         run_args = SafeRunScriptPlugin.Args(
-            origin=str(args.reference_root / "build-asan"),
+            origin=str(args.reference_root / (args.build_type if args.build_type is not None else "build-asan")),
             script=["clang-tidy-19", "-p", ".", "--use-color", "--quiet", *lint_files],
             paths_whitelist=[str(args.reference_root)],
             paths_blacklist=get_cpp_blacklist(args.reference_root),

--- a/checker/plugins/cpp_clang_tidy.py
+++ b/checker/plugins/cpp_clang_tidy.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Optional
 
 from checker.exceptions import PluginExecutionFailed
 from checker.plugins.cpp.blacklist import get_cpp_blacklist

--- a/checker/plugins/cpp_run_benchmarks.py
+++ b/checker/plugins/cpp_run_benchmarks.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import tempfile
 import xml.etree.ElementTree as ET
 from pathlib import Path
@@ -22,6 +23,7 @@ class CppRunBenchmarksPlugin(PluginABC):
         timeout: float
         args: list[str]
         benchmark_values: list[str]
+        env_whitelist: list[str] = list()
 
     @staticmethod
     def _print_logs(path: Path) -> None:
@@ -80,6 +82,10 @@ class CppRunBenchmarksPlugin(PluginABC):
 
     @staticmethod
     def _run_benchmarks(args: Args, tmp_dir: Path, build_dir: Path, target: str, verbose: bool) -> None:
+        # Dump the GPU device we use to benchmark CUDA code if one is set
+        if "CUDA_VISIBLE_DEVICES" in args.env_whitelist:
+            print_info(f"CUDA_VISIBLE_DEVICES is set to `{os.getenv('CUDA_VISIBLE_DEVICES')}`")
+
         xml_path = tmp_dir / CppRunBenchmarksPlugin._REPORT_XML
         run_args = SafeRunScriptPlugin.Args(
             origin=str(build_dir),
@@ -91,6 +97,7 @@ class CppRunBenchmarksPlugin(PluginABC):
                 f"console::out={tmp_dir / CppRunBenchmarksPlugin._REPORT}::colour-mode=ansi",
                 *args.args,
             ],
+            env_whitelist=args.env_whitelist,
             timeout=args.timeout,
         )
         try:

--- a/checker/plugins/cpp_run_tests.py
+++ b/checker/plugins/cpp_run_tests.py
@@ -27,6 +27,7 @@ class CppRunTestsPlugin(PluginABC):
         paths_whitelist: list[str]
         lock_network: bool = True
         cuda_compute_sanitizer: bool = False
+        env_whitelist: list[str] = list()
 
     @staticmethod
     def _get_sanitizers_env(args: Args, path: Path) -> dict[str, str]:
@@ -48,6 +49,10 @@ class CppRunTestsPlugin(PluginABC):
 
     @staticmethod
     def _run_tests(args: Args, tmp_dir: Path, build_dir: Path, target: str, verbose: bool) -> None:
+        # Dump the GPU device we use to test CUDA code if one is set
+        if "CUDA_VISIBLE_DEVICES" in args.env_whitelist:
+            print_info(f"CUDA_VISIBLE_DEVICES is set to `{os.getenv('CUDA_VISIBLE_DEVICES')}`")
+
         env = CppRunTestsPlugin._get_sanitizers_env(args, tmp_dir)
         paths_whitelist = [str(args.root / p) for p in args.paths_whitelist]
         run_args = SafeRunScriptPlugin.Args(
@@ -67,6 +72,7 @@ class CppRunTestsPlugin(PluginABC):
             timeout=args.timeout,
             paths_whitelist=paths_whitelist,
             lock_network=args.lock_network,
+            env_whitelist=args.env_whitelist,
         )
         try:
             SafeRunScriptPlugin()._run(run_args, verbose=verbose)

--- a/checker/plugins/cpp_run_tests.py
+++ b/checker/plugins/cpp_run_tests.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import tempfile
 from pathlib import Path
 

--- a/checker/plugins/cpp_run_tests.py
+++ b/checker/plugins/cpp_run_tests.py
@@ -26,6 +26,7 @@ class CppRunTestsPlugin(PluginABC):
         args: list[str]
         paths_whitelist: list[str]
         lock_network: bool = True
+        cuda_compute_sanitizer: bool = False
 
     @staticmethod
     def _get_sanitizers_env(args: Args, path: Path) -> dict[str, str]:
@@ -51,7 +52,12 @@ class CppRunTestsPlugin(PluginABC):
         paths_whitelist = [str(args.root / p) for p in args.paths_whitelist]
         run_args = SafeRunScriptPlugin.Args(
             origin=str(build_dir),
-            script=[
+            script=(
+                ["compute-sanitizer", "--leak-check", "full", "--error-exitcode", "1"]
+                if args.cuda_compute_sanitizer
+                else []
+            )
+            + [
                 str(build_dir / target),
                 "-r",
                 f"console::out={tmp_dir / CppRunTestsPlugin._REPORT}::colour-mode=ansi",

--- a/checker/plugins/cpp_run_tests.py
+++ b/checker/plugins/cpp_run_tests.py
@@ -58,7 +58,7 @@ class CppRunTestsPlugin(PluginABC):
         run_args = SafeRunScriptPlugin.Args(
             origin=str(build_dir),
             script=(
-                ["compute-sanitizer", "--leak-check", "full", "--error-exitcode", "1"]
+                ["/usr/local/cuda/bin/compute-sanitizer", "--leak-check", "full", "--error-exitcode", "1"]
                 if args.cuda_compute_sanitizer
                 else []
             )


### PR DESCRIPTION
- Update clang-format and clang-tidy
- Allow to use custom CMake build type for clang-tidy runs
- Add CUDA compute sanitizer support for `cpp_run_tests`
- Forward `CUDA_VISIBLE_DEVICES` to `cpp_run_tests` and `cpp_run_benchmarks`. This env variable will be printed to the job log so the student can see which GPU is used to test his submit.